### PR TITLE
fix delta update info

### DIFF
--- a/.github/tools/MakeAppImage.sh
+++ b/.github/tools/MakeAppImage.sh
@@ -13,7 +13,7 @@ export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
 
 APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage"
-UPINFO="gh-releases-zsync|$(echo $GITHUB_REPOSITORY | tr '/' '|')|continuous|*$ARCH.AppImage.zsync"
+UPINFO="gh-releases-zsync|$(echo $GITHUB_REPOSITORY | tr '/' '|')|latest|*$ARCH*.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/tags/v0.4.4/lib4bin"
 
 # Prepare AppDir


### PR DESCRIPTION
This is broken because the artifacts no longer end in `x86_64.AppImage`

It is also broken on probono's repo because the `continuous` tag is no longer being used xd.


--------------------------------------------------------------------

Btw good job on this, I had plans to also make a separate AppImage, but built on archlinux, because that way it can use our infra at pkgforge-dev including the [smaller packages](https://github.com/pkgforge-dev/llvm-libs-debloated) which should make the AppImage less than 200 MiB.

What do you think about doing this yourself instead? 👀 Just let me know. 

